### PR TITLE
Fix MUR-14

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -2,5 +2,4 @@
 spring.datasource.hikari.connectionTimeout=20000
 spring.datasource.hikari.maximumPoolSize=5
 
-#drop n create table again, good for testing, comment this in production
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Removes database credentials from application.properties. These values can easily be set using environment variables, see https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config.

I already enriched the Heroku config by these variables, and you also can easily do so in IntelliJ: Under Run → Edit Configurations, there should be a field named "Environment variables". When you click the document icon on the right of the input field, you can enter the same name-value-pairs that stood in the config file before.

I also changed the value of `hibernate.ddl-auto` so that the database is not purged when the application is restared.