### PR TITLE
fix MUR-15

### DIFF
--- a/backend/src/main/java/de/marvinbrieger/toothbrushgame/controller/GameController.java
+++ b/backend/src/main/java/de/marvinbrieger/toothbrushgame/controller/GameController.java
@@ -6,6 +6,8 @@ import de.marvinbrieger.toothbrushgame.persistence.GameRepository;
 import de.marvinbrieger.toothbrushgame.services.GameCodeService;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collection;
+
 @RestController
 public class GameController {
 
@@ -15,13 +17,18 @@ public class GameController {
         this.gameRepository = gameRepository;
     }
 
-    @GetMapping("/games/{id}")
+    @GetMapping("/games")
+    Collection<Game> getAll() {
+        return gameRepository.findAll();
+    }
+
+    @GetMapping("/games/{id:[0-9]+}")
     Game getOne(@PathVariable Long id) {
         return gameRepository.findById(id)
                 .orElseThrow(() -> new GameNotFoundExeception(id));
     }
 
-    @GetMapping("/games/code_{gameCode}")
+    @GetMapping("/games/{gameCode:[a-zA-Z0-9]*[a-zA-Z][a-zA-Z0-9]*}")
     Game getOne(@PathVariable String gameCode) {
         return gameRepository.findByGameCode(gameCode)
                 .orElseThrow(() -> new GameNotFoundExeception(gameCode));


### PR DESCRIPTION
When getting `/game/1`, Spring Boot could not know if `1` was a game code or game id. Prefixing the game code with `code_` fixes this.

Not a totally RESTful solution, but probably cleaner than defining a separate endpoint.